### PR TITLE
RUBY-1309 Update gem to work with driver

### DIFF
--- a/lib/mongo/auth/kerberos.rb
+++ b/lib/mongo/auth/kerberos.rb
@@ -28,6 +28,18 @@ module Mongo
       # @since 2.0.0
       MECHANISM = 'GSSAPI'.freeze
 
+      # Instantiate a new authenticator.
+      #
+      # example Create the authenticator.
+      #   Mongo::Auth::Kerberos.new(user)
+      #
+      # @param [ Mongo::Auth::User ] user The user to authenticate.
+      #
+      # @since 2.0.1
+      def initialize(user)
+        @user = user
+      end
+
       # Log the user in on the given connection.
       #
       # @example Log the user in.
@@ -40,7 +52,7 @@ module Mongo
       #
       # @since 2.0.0
       def login(connection)
-        conversation = Conversation.new(user, connection.address.host)
+        conversation = Conversation.new(@user, connection.address.host)
         reply = connection.dispatch([ conversation.start ])
         until reply.documents[0][Conversation::DONE]
           reply = connection.dispatch([ conversation.finalize(reply) ])

--- a/lib/mongo/auth/kerberos/version.rb
+++ b/lib/mongo/auth/kerberos/version.rb
@@ -17,7 +17,7 @@ module Mongo
     class Kerberos
 
       # The gem version number.
-      VERSION = '2.0.0'.freeze
+      VERSION = '2.0.1'.freeze
     end
   end
 end

--- a/lib/mongo/auth/kerberos/version.rb
+++ b/lib/mongo/auth/kerberos/version.rb
@@ -17,7 +17,7 @@ module Mongo
     class Kerberos
 
       # The gem version number.
-      VERSION = '2.0.1'.freeze
+      VERSION = '2.1.0'.freeze
     end
   end
 end

--- a/mongo_kerberos.gemspec
+++ b/mongo_kerberos.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 1.9.3'
   s.required_rubygems_version = '>= 1.3.6'
   s.has_rdoc                  = 'yard'
-  s.add_dependency('mongo', "~> 2.0.0")
+  s.add_dependency('mongo', "~> 2.0")
 end


### PR DESCRIPTION
There aren't any integration tests for this (pending RUBY-1311, which this ticket blocks), but I've manually verified that this works with the following code (after building locally and installing):

```ruby
require 'mongo'
require 'mongo_kerberos'

uri = "mongodb://drivers%40LDAPTEST.10GEN.CC@ldaptest.10gen.cc/kerberos?authMechanism=GSSAPI&authSource=$external"
client = Mongo::Client.new(uri)

client.database[:test].find.each do |doc|
  puts doc
end
```