### PR TITLE
Be more defensive in native extension.

### DIFF
--- a/ext/mongo_kerberos/mongo_kerberos_native.c
+++ b/ext/mongo_kerberos/mongo_kerberos_native.c
@@ -20,6 +20,11 @@ static void mongo_sasl_conn_free(void* data) {
   sasl_conn_t *conn = (sasl_conn_t*) data;
   if (conn) {
     sasl_dispose(&conn);
+    /* We do not set connection to NULL in the Ruby object. */
+    /* This is probably fine because this method is supposed to be called */
+    /* when the Ruby object is being garbage collected. */
+    /* Plus, we don't have the Ruby object reference here to do anything */
+    /* with it. */
   }
 }
 
@@ -105,6 +110,9 @@ static VALUE initialize_challenge(VALUE self) {
   }
 
   context = Data_Wrap_Struct(rb_cObject, NULL, mongo_sasl_conn_free, conn);
+  /* I'm guessing ruby raises on out of memory condition rather than */
+  /* returns NULL, hence no error checking is needed here? */
+  
   /* from now on context owns conn */
   /* since mongo_sasl_conn_free cleans up conn, we should NOT call */
   /* sasl_dispose any more in this function. */

--- a/ext/mongo_kerberos/mongo_kerberos_native.c
+++ b/ext/mongo_kerberos/mongo_kerberos_native.c
@@ -116,8 +116,8 @@ static VALUE initialize_challenge(VALUE self) {
   /* from now on context owns conn */
   /* since mongo_sasl_conn_free cleans up conn, we should NOT call */
   /* sasl_dispose any more in this function. */
-  RB_GC_GUARD(context);
   rb_iv_set(self, "@context", context);
+  RB_GC_GUARD(context);
 
   result = sasl_client_start(conn, mechanism_list, NULL, &raw_payload, &raw_payload_len, &mechanism_selected);
   if (is_sasl_failure(result)) {
@@ -128,8 +128,8 @@ static VALUE initialize_challenge(VALUE self) {
     return Qfalse;
   }
 
-  /* I can't tell if the buffer size expected by sasl_encode64 includes */
-  /* the null terminator, thus be defensive and exclude it */
+  /* cyrus-sasl considers `outmax` (fourth argument) to include the null */
+  /* terminator, but this is not documented. Be defensive and exclude it. */
   result = sasl_encode64(raw_payload, raw_payload_len, encoded_payload, sizeof(encoded_payload)-1, &encoded_payload_len);
   if (is_sasl_failure(result)) {
     return Qfalse;


### PR DESCRIPTION
- Explicitly reserve a byte for null terminator in strings
- Only close the connection being worked on with sasl_dispose rather than all of them