### PR TITLE
RUBY-3200 support Ruby 3.2

### DIFF
--- a/mongo_kerberos.gemspec
+++ b/mongo_kerberos.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/mongodb/mongo-ruby-kerberos'
   }
 
-  if File.exists?('gem-private_key.pem')
+  if File.exist?('gem-private_key.pem')
     s.signing_key = 'gem-private_key.pem'
     s.cert_chain  = ['gem-public_cert.pem']
   else


### PR DESCRIPTION
As of Ruby 3.2, the "File.exists?" alias for "File.exist?" is gone. The only way to check for the existence of a file is now "File.exist?".