### PR TITLE
RUBY-3589 Prep for v2.1.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,6 @@ specs should follow the following guidelines:
 - Use `context` blocks to set up conditions.
 - Always provide descriptive specifications via `it`.
 
-Specs can be automatically run with Guard, via `bundle exec guard`
-
 Before commiting, run `rake` to ensure all specs pass with both pure Ruby and
 the native extensions.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,31 @@ Require the `mongo_kerberos` gem in your application.
 require "mongo_kerberos"
 ```
 
+### Release Integrity
+
+Each release of this Kerberos authentication module after version 2.1.1 has been automatically built and signed using the team's GPG key.
+
+To verify the module's gem file:
+
+1. [Download the GPG key](https://pgp.mongodb.com/ruby-driver.asc).
+2. Import the key into your GPG keyring with `gpg --import ruby-driver.asc`.
+3. Download the gem file (if you don't already have it). You can download it from RubyGems with `gem fetch mongo_kerberos`, or you can download it from the [releases page](https://github.com/mongodb/mongo-ruby-kerberos/releases) on GitHub.
+4. Download the corresponding detached signature file from the [same release](https://github.com/mongodb/mongo-ruby-kerberos/releases). Look at the bottom of the release that corresponds to the gem file, under the 'Assets' list, for a `.sig` file with the same version number as the gem you wish to install.
+5. Verify the gem with `gpg --verify mongo_kerberos-X.Y.Z.gem.sig mongo_kerberos-X.Y.Z.gem` (replacing `X.Y.Z` with the actual version number).
+
+You are looking for text like "Good signature from "MongoDB Ruby Driver Release Signing Key <packaging@mongodb.com>" in the output. If you see that, the signature was found to correspond to the given gem file.
+
+(Note that other output, like "This key is not certified with a trusted signature!", is related to *web of trust* and depends on how strongly you, personally, trust the `ruby-driver.asc` key that you downloaded from us. To learn more, see https://www.gnupg.org/gph/en/manual/x334.html)
+
+### Why not use RubyGems' gem-signing functionality?
+
+RubyGems' own gem signing is problematic, most significantly because there is no established chain of trust related to the keys used to sign gems. RubyGems' own documentation admits that "this method of signing gems is not widely used" (see https://guides.rubygems.org/security/). Discussions about this in the RubyGems community have been off-and-on for more than a decade, and while a solution will eventually arrive, we have settled on using GPG instead for the following reasons:
+
+1. Many of the other driver teams at MongoDB are using GPG to sign their product releases. Consistency with the other teams means that we can reuse existing tooling for our own product releases.
+2. GPG is widely available and has existing tools and procedures for dealing with web of trust (though they are admittedly quite arcane and intimidating to the uninitiated, unfortunately).
+
+Ultimately, most users do not bother to verify gems, and will not be impacted by our choice of GPG over RubyGems' native method.
+
 
 ## API Documentation
 

--- a/lib/mongo/auth/kerberos/version.rb
+++ b/lib/mongo/auth/kerberos/version.rb
@@ -1,23 +1,11 @@
-# Copyright (C) 2015 MongoDB, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# frozen_string_literal: true
 
 module Mongo
   module Auth
     class Kerberos
 
       # The gem version number.
-      VERSION = '2.1.1'.freeze
+      VERSION = '2.1.2'
     end
   end
 end


### PR DESCRIPTION
Version 2.1.2 of the Kerberos authentication module for MongoDB's Ruby Driver is now available.

Install it via RubyGems:

```ruby
gem install -v 2.1.2 mongo_kerberos
```

This maintenance release includes the following changes:

* Added support for JRuby 9.4.
* The gems are now signed via GPG; the signature files are available separately on GitHub under the 2.1.2 release.
