### PR TITLE
RUBY-3589 fix gem push task so it actually publishes the gems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,6 @@ jobs:
 
       - name: Publish the gems
         uses: rubygems/release-gem@v1
-        if: inputs.dry_run == 'false'
+        if: inputs.dry_run == false
         with:
           await-release: false


### PR DESCRIPTION
RUBY-3589 is mostly done, but with the previous PR there was a typo in the part that actually publishes the gems (the one part I couldn't actually test with a dry run).